### PR TITLE
Rename tox environment names for easier typing

### DIFF
--- a/.ctt/default/.github/workflows/tests.yml
+++ b/.ctt/default/.github/workflows/tests.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.14
       - uses: j178/prek-action@v1
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
@@ -42,7 +42,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.12
+          python-version: 3.14
       - name: Install prek
         uses: j178/prek-action@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.12
+          python-version: 3.14
       - name: Build Package
         run: uv build
       - name: Publish to PyPI

--- a/.ctt/default/AGENTS.md
+++ b/.ctt/default/AGENTS.md
@@ -6,42 +6,42 @@
 # Run all tests using tox
 tox
 
-# Run tests with coverage (Python 3.10)
-tox -e py310-test
+# Run tests with coverage (Python 3.10 - minimum version)
+tox -e min-test
 
-# Run tests with coverage (Python 3.12)
-tox -e py312-test
+# Run tests with coverage (Python 3.14 - latest version)
+tox -e latest-test
 
 # Run specific tests with pytest flags
-tox -e py312-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
+tox -e latest-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
 ```
 
 ## Linting and Formatting
 
 ```bash
 # Run all pre-commit hooks (using prek)
-tox -e py312-prek
+tox -e latest-prek
 # Or run directly with prek
 prek run --all
 
 # Run ruff for linting and formatting
-tox -e py312-ruff
+tox -e latest-ruff
 # With unsafe fixes
-tox -e py312-ruff -- --unsafe-fixes
+tox -e latest-ruff -- --unsafe-fixes
 ```
 
 ## Type Checking
 
 ```bash
 # Run mypy type checking
-tox -e py312-type
+tox -e latest-type
 ```
 
 ## Pre-commit Hook Testing
 
 ```bash
 # Test the plugin as a pre-commit hook
-tox -e py310-hook
+tox -e min-hook
 ```
 
 ## Architecture
@@ -88,7 +88,7 @@ Configuration can be passed via:
 ## Development Notes
 
 - This project uses `uv-build` as the build backend
-- Uses `tox` for test automation with multiple Python versions (3.10, 3.12)
+- Uses `tox` for test automation with multiple Python versions (3.10, 3.14)
 - Pre-commit is configured but the project now uses `prek` (faster alternative)
 - Python 3.10+ is required (see `requires-python` in `pyproject.toml`)
 - Version is defined in `mdformat_eb_plugin_example/__init__.py` as `__version__`

--- a/.ctt/default/AGENTS.md
+++ b/.ctt/default/AGENTS.md
@@ -6,42 +6,42 @@
 # Run all tests using tox
 tox
 
-# Run tests with coverage (Python 3.10 - minimum version)
-tox -e min-test
+# Run tests with coverage (Python 3.14 - current version)
+tox -e test
 
-# Run tests with coverage (Python 3.14 - latest version)
-tox -e latest-test
+# Run tests with coverage (Python 3.10 - minimum version)
+tox -e test-min
 
 # Run specific tests with pytest flags
-tox -e latest-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
+tox -e test -- --exitfirst --failed-first --new-first -vv --snapshot-update
 ```
 
 ## Linting and Formatting
 
 ```bash
 # Run all pre-commit hooks (using prek)
-tox -e latest-prek
+tox -e prek
 # Or run directly with prek
 prek run --all
 
 # Run ruff for linting and formatting
-tox -e latest-ruff
+tox -e ruff
 # With unsafe fixes
-tox -e latest-ruff -- --unsafe-fixes
+tox -e ruff -- --unsafe-fixes
 ```
 
 ## Type Checking
 
 ```bash
 # Run mypy type checking
-tox -e latest-type
+tox -e type
 ```
 
 ## Pre-commit Hook Testing
 
 ```bash
 # Test the plugin as a pre-commit hook
-tox -e min-hook
+tox -e hook-min
 ```
 
 ## Architecture

--- a/.ctt/default/CONTRIBUTING.md
+++ b/.ctt/default/CONTRIBUTING.md
@@ -27,7 +27,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e py310-test
+tox -e min-test
 ```
 
 The easiest way to write tests, is to edit `tests/fixtures.md`
@@ -35,7 +35,7 @@ The easiest way to write tests, is to edit `tests/fixtures.md`
 To run the code formatting and style checks:
 
 ```bash
-tox -e py312-prek
+tox -e latest-prek
 ```
 
 or directly with [prek](https://github.com/j178/prek) (or pre-commit)
@@ -51,7 +51,7 @@ prek run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e py310-hook
+tox -e min-hook
 ```
 
 ## `ptw` testing
@@ -108,13 +108,13 @@ Use commitizen to automatically bump versions and create a commit with tag:
 
 ```sh
 # Dry run to preview the version bump
-tox -e py312-cz -- --dry-run
+tox -e latest-cz -- --dry-run
 
 # Automatically bump version based on conventional commits
-tox -e py312-cz
+tox -e latest-cz
 
 # Or manually specify the increment type
-tox -e py312-cz -- --increment PATCH  # or MINOR or MAJOR
+tox -e latest-cz -- --increment PATCH  # or MINOR or MAJOR
 
 # Push the commit and tag
 git push origin main --tags

--- a/.ctt/default/CONTRIBUTING.md
+++ b/.ctt/default/CONTRIBUTING.md
@@ -27,7 +27,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e min-test
+tox -e test
 ```
 
 The easiest way to write tests, is to edit `tests/fixtures.md`
@@ -35,7 +35,7 @@ The easiest way to write tests, is to edit `tests/fixtures.md`
 To run the code formatting and style checks:
 
 ```bash
-tox -e latest-prek
+tox -e prek
 ```
 
 or directly with [prek](https://github.com/j178/prek) (or pre-commit)
@@ -51,7 +51,7 @@ prek run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e min-hook
+tox -e hook-min
 ```
 
 ## `ptw` testing
@@ -108,13 +108,13 @@ Use commitizen to automatically bump versions and create a commit with tag:
 
 ```sh
 # Dry run to preview the version bump
-tox -e latest-cz -- --dry-run
+tox -e cz -- --dry-run
 
 # Automatically bump version based on conventional commits
-tox -e latest-cz
+tox -e cz
 
 # Or manually specify the increment type
-tox -e latest-cz -- --increment PATCH  # or MINOR or MAJOR
+tox -e cz -- --increment PATCH  # or MINOR or MAJOR
 
 # Push the commit and tag
 git push origin main --tags

--- a/.ctt/default/pyproject.toml
+++ b/.ctt/default/pyproject.toml
@@ -156,21 +156,25 @@ requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
 [tool.tox.env.cz]
+basepython = "python3.14"
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
 [tool.tox.env."hook-min"]
+basepython = "python3.10"
 commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 
 [tool.tox.env.prek]
+basepython = "python3.14"
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
 [tool.tox.env.ruff]
+basepython = "python3.14"
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -180,6 +184,7 @@ description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
 [tool.tox.env.test]
+basepython = "python3.14"
 commands = [["pytest", "--cov=mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_eb_plugin_example"
@@ -187,10 +192,12 @@ description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -
 extras = ["test"]
 
 [tool.tox.env."test-min"]
+basepython = "python3.10"
 commands = [["pytest", "--cov=mdformat_eb_plugin_example"]]
 extras = ["test"]
 
 [tool.tox.env.type]
+basepython = "python3.14"
 commands = [["mypy", "./mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 

--- a/.ctt/default/pyproject.toml
+++ b/.ctt/default/pyproject.toml
@@ -71,8 +71,8 @@ now = true
 patterns = ["*.ambr", "*.md", "*.py"]
 runner = "tox"
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
-# runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_eb_plugin_example"]
-runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
+# runner_args = ["-e", "test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_eb_plugin_example"]
+runner_args = ["-e", "test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
 
 [tool.ruff]
 # Docs: https://github.com/charliermarsh/ruff
@@ -150,31 +150,27 @@ inline_arrays = false
 [tool.tox]
 # Docs: https://tox.wiki/en/4.23.2/config.html#core
 basepython = ["python3.10", "python3.14"]
-env_list = ["min-hook", "min-test", "latest-cz", "latest-prek", "latest-ruff", "latest-test", "latest-type"]
+env_list = ["cz", "hook-min", "prek", "ruff", "test", "test-min", "type"]
 isolated_build = true
 requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
-[tool.tox.env."min-hook"]
-commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
-deps = "prek>=0.2.17"
-
-[tool.tox.env."min-test"]
-commands = [["pytest", "--cov=mdformat_eb_plugin_example"]]
-extras = ["test"]
-
-[tool.tox.env."latest-cz"]
+[tool.tox.env.cz]
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
-[tool.tox.env."latest-prek"]
+[tool.tox.env."hook-min"]
+commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
+deps = "prek>=0.2.17"
+
+[tool.tox.env.prek]
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
-[tool.tox.env."latest-ruff"]
+[tool.tox.env.ruff]
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -183,14 +179,18 @@ deps = "ruff>=0.14.5"
 description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
-[tool.tox.env."latest-test"]
+[tool.tox.env.test]
 commands = [["pytest", "--cov=mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_eb_plugin_example"
 description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv"
 extras = ["test"]
 
-[tool.tox.env."latest-type"]
+[tool.tox.env."test-min"]
+commands = [["pytest", "--cov=mdformat_eb_plugin_example"]]
+extras = ["test"]
+
+[tool.tox.env.type]
 commands = [["mypy", "./mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 

--- a/.ctt/default/pyproject.toml
+++ b/.ctt/default/pyproject.toml
@@ -71,8 +71,8 @@ now = true
 patterns = ["*.ambr", "*.md", "*.py"]
 runner = "tox"
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
-# runner_args = ["-e", "py312-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_eb_plugin_example"]
-runner_args = ["-e", "py312-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
+# runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_eb_plugin_example"]
+runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
 
 [tool.ruff]
 # Docs: https://github.com/charliermarsh/ruff
@@ -149,32 +149,32 @@ inline_arrays = false
 
 [tool.tox]
 # Docs: https://tox.wiki/en/4.23.2/config.html#core
-basepython = ["python3.10", "python3.12"]
-env_list = ["py310-hook", "py310-test", "py312-cz", "py312-prek", "py312-ruff", "py312-test", "py312-type"]
+basepython = ["python3.10", "python3.14"]
+env_list = ["min-hook", "min-test", "latest-cz", "latest-prek", "latest-ruff", "latest-test", "latest-type"]
 isolated_build = true
 requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
-[tool.tox.env."py310-hook"]
+[tool.tox.env."min-hook"]
 commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 
-[tool.tox.env."py310-test"]
+[tool.tox.env."min-test"]
 commands = [["pytest", "--cov=mdformat_eb_plugin_example"]]
 extras = ["test"]
 
-[tool.tox.env."py312-cz"]
+[tool.tox.env."latest-cz"]
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
-[tool.tox.env."py312-prek"]
+[tool.tox.env."latest-prek"]
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
-[tool.tox.env."py312-ruff"]
+[tool.tox.env."latest-ruff"]
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -183,14 +183,14 @@ deps = "ruff>=0.14.5"
 description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
-[tool.tox.env."py312-test"]
+[tool.tox.env."latest-test"]
 commands = [["pytest", "--cov=mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_eb_plugin_example"
 description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv"
 extras = ["test"]
 
-[tool.tox.env."py312-type"]
+[tool.tox.env."latest-type"]
 commands = [["mypy", "./mdformat_eb_plugin_example", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 

--- a/package_template/.github/workflows/tests.yml.jinja
+++ b/package_template/.github/workflows/tests.yml.jinja
@@ -15,14 +15,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.14
       - uses: j178/prek-action@v1
 
   tests:
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.14"]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
@@ -42,7 +42,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.12
+          python-version: 3.14
       - name: Install prek
         uses: j178/prek-action@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.12
+          python-version: 3.14
       - name: Build Package
         run: uv build
       - name: Publish to PyPI

--- a/package_template/AGENTS.md.jinja
+++ b/package_template/AGENTS.md.jinja
@@ -6,42 +6,42 @@
 # Run all tests using tox
 tox
 
-# Run tests with coverage (Python 3.10)
-tox -e py310-test
+# Run tests with coverage (Python 3.10 - minimum version)
+tox -e min-test
 
-# Run tests with coverage (Python 3.12)
-tox -e py312-test
+# Run tests with coverage (Python 3.14 - latest version)
+tox -e latest-test
 
 # Run specific tests with pytest flags
-tox -e py312-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
+tox -e latest-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
 ```
 
 ## Linting and Formatting
 
 ```bash
 # Run all pre-commit hooks (using prek)
-tox -e py312-prek
+tox -e latest-prek
 # Or run directly with prek
 prek run --all
 
 # Run ruff for linting and formatting
-tox -e py312-ruff
+tox -e latest-ruff
 # With unsafe fixes
-tox -e py312-ruff -- --unsafe-fixes
+tox -e latest-ruff -- --unsafe-fixes
 ```
 
 ## Type Checking
 
 ```bash
 # Run mypy type checking
-tox -e py312-type
+tox -e latest-type
 ```
 
 ## Pre-commit Hook Testing
 
 ```bash
 # Test the plugin as a pre-commit hook
-tox -e py310-hook
+tox -e min-hook
 ```
 
 ## Architecture
@@ -88,7 +88,7 @@ Configuration can be passed via:
 ## Development Notes
 
 - This project uses `uv-build` as the build backend
-- Uses `tox` for test automation with multiple Python versions (3.10, 3.12)
+- Uses `tox` for test automation with multiple Python versions (3.10, 3.14)
 - Pre-commit is configured but the project now uses `prek` (faster alternative)
 - Python 3.10+ is required (see `requires-python` in `pyproject.toml`)
 - Version is defined in `mdformat_{{ plugin_name }}/__init__.py` as `__version__`

--- a/package_template/AGENTS.md.jinja
+++ b/package_template/AGENTS.md.jinja
@@ -6,42 +6,42 @@
 # Run all tests using tox
 tox
 
-# Run tests with coverage (Python 3.10 - minimum version)
-tox -e min-test
+# Run tests with coverage (Python 3.14 - current version)
+tox -e test
 
-# Run tests with coverage (Python 3.14 - latest version)
-tox -e latest-test
+# Run tests with coverage (Python 3.10 - minimum version)
+tox -e test-min
 
 # Run specific tests with pytest flags
-tox -e latest-test -- --exitfirst --failed-first --new-first -vv --snapshot-update
+tox -e test -- --exitfirst --failed-first --new-first -vv --snapshot-update
 ```
 
 ## Linting and Formatting
 
 ```bash
 # Run all pre-commit hooks (using prek)
-tox -e latest-prek
+tox -e prek
 # Or run directly with prek
 prek run --all
 
 # Run ruff for linting and formatting
-tox -e latest-ruff
+tox -e ruff
 # With unsafe fixes
-tox -e latest-ruff -- --unsafe-fixes
+tox -e ruff -- --unsafe-fixes
 ```
 
 ## Type Checking
 
 ```bash
 # Run mypy type checking
-tox -e latest-type
+tox -e type
 ```
 
 ## Pre-commit Hook Testing
 
 ```bash
 # Test the plugin as a pre-commit hook
-tox -e min-hook
+tox -e hook-min
 ```
 
 ## Architecture

--- a/package_template/CONTRIBUTING.md.jinja
+++ b/package_template/CONTRIBUTING.md.jinja
@@ -27,7 +27,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e py310-test
+tox -e min-test
 ```
 
 The easiest way to write tests, is to edit `tests/fixtures.md`
@@ -35,7 +35,7 @@ The easiest way to write tests, is to edit `tests/fixtures.md`
 To run the code formatting and style checks:
 
 ```bash
-tox -e py312-prek
+tox -e latest-prek
 ```
 
 or directly with [prek](https://github.com/j178/prek) (or pre-commit)
@@ -51,7 +51,7 @@ prek run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e py310-hook
+tox -e min-hook
 ```
 
 ## `ptw` testing
@@ -108,13 +108,13 @@ Use commitizen to automatically bump versions and create a commit with tag:
 
 ```sh
 # Dry run to preview the version bump
-tox -e py312-cz -- --dry-run
+tox -e latest-cz -- --dry-run
 
 # Automatically bump version based on conventional commits
-tox -e py312-cz
+tox -e latest-cz
 
 # Or manually specify the increment type
-tox -e py312-cz -- --increment PATCH  # or MINOR or MAJOR
+tox -e latest-cz -- --increment PATCH  # or MINOR or MAJOR
 
 # Push the commit and tag
 git push origin main --tags

--- a/package_template/CONTRIBUTING.md.jinja
+++ b/package_template/CONTRIBUTING.md.jinja
@@ -27,7 +27,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e min-test
+tox -e test
 ```
 
 The easiest way to write tests, is to edit `tests/fixtures.md`
@@ -35,7 +35,7 @@ The easiest way to write tests, is to edit `tests/fixtures.md`
 To run the code formatting and style checks:
 
 ```bash
-tox -e latest-prek
+tox -e prek
 ```
 
 or directly with [prek](https://github.com/j178/prek) (or pre-commit)
@@ -51,7 +51,7 @@ prek run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e min-hook
+tox -e hook-min
 ```
 
 ## `ptw` testing
@@ -108,13 +108,13 @@ Use commitizen to automatically bump versions and create a commit with tag:
 
 ```sh
 # Dry run to preview the version bump
-tox -e latest-cz -- --dry-run
+tox -e cz -- --dry-run
 
 # Automatically bump version based on conventional commits
-tox -e latest-cz
+tox -e cz
 
 # Or manually specify the increment type
-tox -e latest-cz -- --increment PATCH  # or MINOR or MAJOR
+tox -e cz -- --increment PATCH  # or MINOR or MAJOR
 
 # Push the commit and tag
 git push origin main --tags

--- a/package_template/pyproject.toml.jinja
+++ b/package_template/pyproject.toml.jinja
@@ -71,8 +71,8 @@ now = true
 patterns = ["*.ambr", "*.md", "*.py"]
 runner = "tox"
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
-# runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_{{ plugin_name }}"]
-runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
+# runner_args = ["-e", "test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_{{ plugin_name }}"]
+runner_args = ["-e", "test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
 
 [tool.ruff]
 # Docs: https://github.com/charliermarsh/ruff
@@ -150,31 +150,31 @@ inline_arrays = false
 [tool.tox]
 # Docs: https://tox.wiki/en/4.23.2/config.html#core
 basepython = ["python3.10", "python3.14"]
-env_list = ["min-hook", "min-test", "latest-cz", "latest-prek", "latest-ruff", "latest-test", "latest-type"]
+env_list = ["hook-min", "test-min", "cz", "prek", "ruff", "test", "type"]
 isolated_build = true
 requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
-[tool.tox.env."min-hook"]
+[tool.tox.env."hook-min"]
 commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 
-[tool.tox.env."min-test"]
+[tool.tox.env."test-min"]
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}"]]
 extras = ["test"]
 
-[tool.tox.env."latest-cz"]
+[tool.tox.env.cz]
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
-[tool.tox.env."latest-prek"]
+[tool.tox.env.prek]
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
-[tool.tox.env."latest-ruff"]
+[tool.tox.env.ruff]
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -183,14 +183,14 @@ deps = "ruff>=0.14.5"
 description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
-[tool.tox.env."latest-test"]
+[tool.tox.env.test]
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_{{ plugin_name }}"
 description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv"
 extras = ["test"]
 
-[tool.tox.env."latest-type"]
+[tool.tox.env.type]
 commands = [["mypy", "./mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 

--- a/package_template/pyproject.toml.jinja
+++ b/package_template/pyproject.toml.jinja
@@ -156,25 +156,30 @@ requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
 [tool.tox.env."hook-min"]
+basepython = "python3.10"
 commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 
 [tool.tox.env."test-min"]
+basepython = "python3.10"
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}"]]
 extras = ["test"]
 
 [tool.tox.env.cz]
+basepython = "python3.14"
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
 [tool.tox.env.prek]
+basepython = "python3.14"
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
 [tool.tox.env.ruff]
+basepython = "python3.14"
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -184,6 +189,7 @@ description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
 [tool.tox.env.test]
+basepython = "python3.14"
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_{{ plugin_name }}"
@@ -191,6 +197,7 @@ description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -
 extras = ["test"]
 
 [tool.tox.env.type]
+basepython = "python3.14"
 commands = [["mypy", "./mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 

--- a/package_template/pyproject.toml.jinja
+++ b/package_template/pyproject.toml.jinja
@@ -71,8 +71,8 @@ now = true
 patterns = ["*.ambr", "*.md", "*.py"]
 runner = "tox"
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
-# runner_args = ["-e", "py312-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_{{ plugin_name }}"]
-runner_args = ["-e", "py312-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
+# runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv", "--beartype-packages=mdformat_{{ plugin_name }}"]
+runner_args = ["-e", "latest-test", "--", "--exitfirst", "--failed-first", "--new-first", "-vv"]
 
 [tool.ruff]
 # Docs: https://github.com/charliermarsh/ruff
@@ -149,32 +149,32 @@ inline_arrays = false
 
 [tool.tox]
 # Docs: https://tox.wiki/en/4.23.2/config.html#core
-basepython = ["python3.10", "python3.12"]
-env_list = ["py310-hook", "py310-test", "py312-cz", "py312-prek", "py312-ruff", "py312-test", "py312-type"]
+basepython = ["python3.10", "python3.14"]
+env_list = ["min-hook", "min-test", "latest-cz", "latest-prek", "latest-ruff", "latest-test", "latest-type"]
 isolated_build = true
 requires = ["tox>=4.32.0"]
 skip_missing_interpreters = false
 
-[tool.tox.env."py310-hook"]
+[tool.tox.env."min-hook"]
 commands = [["prek", "run", "--config=.pre-commit-test.yaml", "--all-files", {default = ["--show-diff-on-failure", "--verbose"], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 
-[tool.tox.env."py310-test"]
+[tool.tox.env."min-test"]
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}"]]
 extras = ["test"]
 
-[tool.tox.env."py312-cz"]
+[tool.tox.env."latest-cz"]
 commands = [["cz", "bump", {default = [], extend = true, replace = "posargs"}]]
 deps = "commitizen>=4.10.0"
 description = "Bump version using commitizen. Optionally specify: '-- --increment MAJOR|MINOR|PATCH' or '-- --dry-run'"
 skip_install = true
 
-[tool.tox.env."py312-prek"]
+[tool.tox.env."latest-prek"]
 commands = [["prek", "run", "--all-files", {default = [], extend = true, replace = "posargs"}]]
 deps = "prek>=0.2.17"
 skip_install = true
 
-[tool.tox.env."py312-ruff"]
+[tool.tox.env."latest-ruff"]
 commands = [
   ["ruff", "check", ".", "--fix", {default = [], extend = true, replace = "posargs"}],
   ["ruff", "format", "."],
@@ -183,14 +183,14 @@ deps = "ruff>=0.14.5"
 description = "Optionally, specify: '-- --unsafe-fixes'"
 skip_install = true
 
-[tool.tox.env."py312-test"]
+[tool.tox.env."latest-test"]
 commands = [["pytest", "--cov=mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 # PLANNED: requires support for TYPE_CHECKING https://github.com/beartype/beartype/issues/477
 # description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv --beartype-packages=mdformat_{{ plugin_name }}"
 description = "Optionally, specify: '-- --exitfirst --failed-first --new-first -vv"
 extras = ["test"]
 
-[tool.tox.env."py312-type"]
+[tool.tox.env."latest-type"]
 commands = [["mypy", "./mdformat_{{ plugin_name }}", {default = [], extend = true, replace = "posargs"}]]
 deps = ["mypy>=1.18.2"]
 


### PR DESCRIPTION
- Rename py310-* environments to *-min (minimum supported version)
- Rename py312-* environments to * (no prefix or suffix to be easier to type, the latest supported version)
- Update "latest" Python version from 3.12 to 3.14 where used
- Update all documentation references in CONTRIBUTING.md and AGENTS.md
- Keep Python 3.10 as the minimum supported version

The new naming convention:
- test-min, hook-min: Run on Python 3.10 (minimum version)
- test, cz, prek, ruff, type: Run on Python 3.14 (latest version)

This makes environment names more intuitive and easier to type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and contribution guides to use consolidated tox/env names and reflect supported Python range (3.10 → 3.14).

* **Chores**
  * Modernized and simplified tox/env naming and commands, merging per-version targets into concise environments.
  * Updated CI and test workflows to target Python 3.14.
  * Harmonized test, lint, and type-check commands across project templates and tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->